### PR TITLE
Cambiado el programa salvajes.c (practica6)

### DIFF
--- a/practicas/ficheros_p6/salvajes.c
+++ b/practicas/ficheros_p6/salvajes.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
-    int id = atoi(argv[1]);
+    int id = getpid(); // Suponemos que el pid que se asigna es único
 
     int shm_fd = shm_open(SHM_NAME, O_RDWR, 0666);
     if (shm_fd == -1) {

--- a/practicas/ficheros_p6/salvajes.c
+++ b/practicas/ficheros_p6/salvajes.c
@@ -33,12 +33,7 @@ void eat(int id) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        fprintf(stderr, "Uso: %s <id_salvaje>\n", argv[0]);
-        exit(1);
-    }
-
-    int id = getpid(); // Suponemos que el pid que se asigna es único
+    int id = getpid();
 
     int shm_fd = shm_open(SHM_NAME, O_RDWR, 0666);
     if (shm_fd == -1) {


### PR DESCRIPTION
#1 Issue original

Ahora ya no se usa un id con ejecutar el programa cogerá el id del proceso que ejecuta

´´´
int id = getpid();

    int shm_fd = shm_open(SHM_NAME, O_RDWR, 0666);
    if (shm_fd == -1) {
        perror("[SALVAJE] Error al abrir memoria compartida. Asegúrese de que el cocinero está ejecutándose");
        exit(1);
    }

    caldero = mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
    if (caldero == MAP_FAILED) {
        perror("[SALVAJE] Error al mapear memoria compartida");
        exit(1);
    }

    sem_empty = sem_open(SEM_EMPTY, 0);
    sem_full = sem_open(SEM_FULL, 0);
    sem_mutex = sem_open(SEM_MUTEX, 0);

    if (sem_empty == SEM_FAILED || sem_full == SEM_FAILED || sem_mutex == SEM_FAILED) {
        perror("[SALVAJE] Error al abrir semáforos");
        exit(1);
    }

    for (int i = 0; i < NUMITER; i++) {
        getServingFromPot(id);
        eat(id);
    }

    printf("[SALVAJE %d] Ha terminado.\n", id);
    return 0;
´´´